### PR TITLE
Rename sapling_crypto to franklin_crypto and remove misleading code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ num-bigint = "0.2"
 ff = { package = "ff_ce", version = "0.6.0", features = ["derive"] }
 pairing = { package = "pairing_ce", version = "0.17.0" }
 bellman = { package = "bellman_ce", version = "0.3.0" }
-#sapling-crypto = { package = "sapling-crypto_ce", version = "0.0.5" }
 franklin-crypto = { path = "franklin-crypto" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,21 +4,6 @@ extern crate rand;
 extern crate ff;
 extern crate franklin_crypto;
 
-use franklin_crypto::circuit::boolean::{Boolean, AllocatedBit};
-
-// use sapling_crypto::circuit::{
-//     Assignment,
-//     boolean,
-//     ecc,
-//     pedersen_hash,
-//     blake2s,
-//     sha256,
-//     num,
-//     multipack,
-//     baby_eddsa,
-//     float_point,
-// };
-
 use bellman::{Circuit, ConstraintSystem, SynthesisError};
 use ff::{Field, PrimeField};
 use pairing::{Engine};
@@ -40,10 +25,6 @@ struct XorCircuit<E: Engine> {
     c: Option<E::Fr>,
 }
 
-macro_rules! csprintln {
-    ($x:expr,$($arg:tt)*) => (if $x {println!($($arg)*)});
-}
-
 // Implementation of our circuit:
 // Given a bit `c`, prove that we know bits `a` and `b` such that `c = a xor b`
 impl<E: Engine> Circuit<E> for XorCircuit<E> {
@@ -59,10 +40,6 @@ impl<E: Engine> Circuit<E> for XorCircuit<E> {
         
         let a = cs.alloc(|| "a", || self.a.grab())?;
 
-        let a_bit = Boolean::from(AllocatedBit::alloc(
-            cs.namespace(|| "bit_a"), Some(true)
-        )?);
-
         // a * a = a
         cs.enforce(|| "a is a boolean", |lc| lc + a, |lc| lc + a, |lc| lc + a);
 
@@ -73,8 +50,6 @@ impl<E: Engine> Circuit<E> for XorCircuit<E> {
 
         // c = a xor b
         let c = cs.alloc_input(|| "c", || self.c.grab())?;
-
-        csprintln!(true, "hey!!! {:?}", a_bit.get_value());
 
         // 2a * b = a + b - c
         cs.enforce(
@@ -139,7 +114,7 @@ fn main() {
 mod tests {
 
 use super::*;
-use sapling_crypto::circuit::test::TestConstraintSystem;
+use franklin_crypto::circuit::test::TestConstraintSystem;
 
     #[test]
     fn test_circuit() {


### PR DESCRIPTION
- Fixes `cargo test`
- Removes unnecessary/misleading high-level variable `a_bit` and macro `csprintln!`